### PR TITLE
Make backend listen on 127.0.0.1:8001 instead of 0.0.0.0:8001

### DIFF
--- a/scripts/setup-circus.sh
+++ b/scripts/setup-circus.sh
@@ -10,7 +10,7 @@ statsd = true
 [watcher:taiga]
 working_dir = /home/$USER/taiga-back
 cmd = gunicorn
-args = -w 3 -t 60 --pythonpath=. -b 0.0.0.0:8001 taiga.wsgi
+args = -w 3 -t 60 --pythonpath=. -b 127.0.0.1:8001 taiga.wsgi
 uid = $USER
 numprocesses = 1
 autostart = true

--- a/scripts/setup-config.sh
+++ b/scripts/setup-config.sh
@@ -57,7 +57,7 @@ function taiga-runserver-back {
     circusctl stop taiga
     workon taiga
     cd ~/taiga-back
-    python manage.py runserver 0.0.0.0:8001
+    python manage.py runserver 127.0.0.1:8001
 }
 EOF
 


### PR DESCRIPTION
Currently backend listens to connections on all interfaces.
It does not seem necessary for production deployments, since requests are handled by local nginx.
It does not seem not necessary for dev, since it is unlikely to be used remotely.

Unless there's some use case for direct remote connections to backend in default setup, it's better to only allow connections through nginx.