### PR TITLE
Install Ruby and Node with setup-devel.sh

### DIFF
--- a/scripts/setup-common.sh
+++ b/scripts/setup-common.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+
+if [[ $EUID -eq 0 ]]; then
+  echo "taiga-scripts doesn't works properly if it used with root user." 1>&2
+  exit 1
+fi
+
+pushd ~
+mkdir -p logs
+mkdir -p conf
+popd
+
+# Bootstrap
+# source ./scripts/setup-vars.sh
+source ./scripts/setup-config.sh
+source ./scripts/setup-apt.sh
+
+# Setup and install services dependencies
+source ./scripts/setup-postgresql.sh
+#source ./scripts/setup-redis.sh
+#source ./scripts/setup-rabbitmq.sh
+
+# Setup and install Python related dependencies
+source ./scripts/setup-buildessential.sh
+source ./scripts/setup-python.sh
+
+# Setup Taiga backend
+source ./scripts/setup-backend.sh

--- a/scripts/setup-frontend-dev.sh
+++ b/scripts/setup-frontend-dev.sh
@@ -1,0 +1,44 @@
+#!/bin/bash
+
+FRONTEND_VERSION="stable"
+
+pushd ~
+
+cat > /tmp/conf.json <<EOF
+{
+    "api": "http://127.0.0.1:8000/api/v1/",
+    "eventsUrl": null,
+    "debug": "true",
+    "publicRegisterEnabled": true,
+    "feedbackEnabled": false,
+    "privacyPolicyUrl": null,
+    "termsOfServiceUrl": null,
+    "maxUploadFileSize": null,
+    "gitHubClientId": null,
+    "contribPlugins": []
+}
+EOF
+
+
+if [ ! -e ~/taiga-front ]; then
+    # Initial clear
+    git clone https://github.com/taigaio/taiga-front.git taiga-front
+    pushd ~/taiga-front
+    git checkout -f $FRONTEND_VERSION
+    mkdir -p dist/js
+    mv /tmp/conf.json dist/js/
+    popd
+else
+    pushd ~/taiga-front
+    git fetch
+    git checkout -f $FRONTEND_VERSION
+    git reset --hard origin/stable
+    popd
+fi
+
+pushd ~/taiga-front
+npm install
+bower install --config.interactive=false
+popd
+
+popd

--- a/scripts/setup-node.sh
+++ b/scripts/setup-node.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+# https://nodejs.org/en/download/package-manager/
+curl -sL https://deb.nodesource.com/setup_4.x | sudo -E bash -
+sudo apt-get install -y nodejs
+sudo npm install -g gulp bower
+sudo rm -rf ~/.npm

--- a/scripts/setup-ruby.sh
+++ b/scripts/setup-ruby.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+sudo apt-get install -y ruby
+gem install --user-install sass scss_lint
+echo "export PATH=~/.gem/ruby/1.9.1/bin:\$PATH" >> ~/.bashrc
+source ~/.bashrc

--- a/setup-devel.sh
+++ b/setup-devel.sh
@@ -1,26 +1,10 @@
 #!/bin/bash
 
+source ./scripts/setup-common.sh
 
-pushd ~
-mkdir -p logs
-mkdir -p conf
-popd
+# Setup tools for building the frontend
+source ./scripts/setup-ruby.sh
+source ./scripts/setup-node.sh
 
-# Bootstrap
-# source ./scripts/setup-vars.sh
-source ./scripts/setup-config.sh
-source ./scripts/setup-apt.sh
-
-# Setup and install services dependencies
-source ./scripts/setup-postgresql.sh
-#source ./scripts/setup-redis.sh
-#source ./scripts/setup-rabbitmq.sh
-
-# Setup and install python related dependencies
-source ./scripts/setup-buildessential.sh
-source ./scripts/setup-python.sh
-
-# Setup Taiga
-source ./scripts/setup-frontend.sh
-source ./scripts/setup-backend.sh
-
+# Setup Taiga frontend
+source ./scripts/setup-frontend-dev.sh

--- a/setup-server.sh
+++ b/setup-server.sh
@@ -1,11 +1,9 @@
 #!/bin/bash
 
-if [[ $EUID -eq 0 ]]; then
-  echo "taiga-scripts doesn't works properly if it used with root user." 1>&2
-  exit 1
-fi
+source ./scripts/setup-common.sh
 
-source ./setup-devel.sh
+# Setup Taiga frontend
+source ./scripts/setup-frontend.sh
 
 # Post Setup Services
 source ./scripts/setup-circus.sh


### PR DESCRIPTION
Let `setup-server.sh` install the compiled version of the frontend, while `setup-devel.sh` installs the frontend source repository including Ruby, Node, Gulp and Bower.

`setup-server.sh` works just as it did before, i.e. it installs the compiled version of the frontend. However, `setup-devel.sh` has been changed to install the regular source code repository of the frontend, including the tools necessary to compile it. This automates the frontend chapter of the setup instructions at http://taigaio.github.io/taiga-doc/dist/setup-development.html#_frontend_installation.
