### PR TITLE
Non-interactive mode

### DIFF
--- a/scripts/setup-apt.sh
+++ b/scripts/setup-apt.sh
@@ -20,5 +20,5 @@ function package-not-installed {
 }
 
 sudo apt-get -y update
-sudo apt-get -y upgrade
-sudo apt-get -y dist-upgrade
+sudo apt-get -yq upgrade
+sudo apt-get -yq dist-upgrade


### PR DESCRIPTION
Non-interactive mode for apt-get. This would help in avoiding pop-ups appearing from Ubuntu's grub updates on /boot/grub/menu.lst.