### PR TITLE
add header to nginx to prevent clickjacking

### DIFF
--- a/scripts/setup-nginx.sh
+++ b/scripts/setup-nginx.sh
@@ -27,6 +27,7 @@ server {
         proxy_set_header X-Forwarded-For \$proxy_add_x_forwarded_for;
         proxy_pass http://127.0.0.1:8001/api;
         proxy_redirect off;
+        add_header X-Frame-Options "SAMEORIGIN" always;
     }
     
     # Django admin access (/admin/)


### PR DESCRIPTION
Add”add_header X-Frame-Options "SAMEORIGIN" always;” to nginx configuration