### PR TITLE
Ubuntu Server 20.04 LTS Update

### DIFF
--- a/scripts/setup-buildessential.sh
+++ b/scripts/setup-buildessential.sh
@@ -1,3 +1,5 @@
+mkdir -p ~/.setup
+
 if [ ! -e ~/.setup/buildessential ]; then
     touch ~/.setup/buildessential
 

--- a/scripts/setup-buildessential.sh
+++ b/scripts/setup-buildessential.sh
@@ -1,7 +1,7 @@
 if [ ! -e ~/.setup/buildessential ]; then
     touch ~/.setup/buildessential
 
-    apt-install-if-needed build-essential binutils-doc autoconf flex bison libjpeg-dev libfreetype6-dev zlib1g-dev libzmq3-dev libgdbm-dev libncurses5-dev automake libtool libffi-dev curl gettext cairo
+    apt-install-if-needed build-essential binutils-doc autoconf flex bison libjpeg-dev libfreetype6-dev zlib1g-dev libzmq3-dev libgdbm-dev libncurses5-dev automake libtool libffi-dev curl gettext libcairo2-dev
 
     # Utils
     apt-install-if-needed git tmux

--- a/scripts/setup-circus.sh
+++ b/scripts/setup-circus.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-apt-install-if-needed circus
+pip3 install circus
 
 cat > /tmp/taiga-circus.ini <<EOF
 [watcher:taiga]

--- a/scripts/setup-circus.sh
+++ b/scripts/setup-circus.sh
@@ -30,6 +30,8 @@ HOME=/home/$USER
 PYTHONPATH=/home/$USER/.local/lib/python3.4/site-packages
 EOF
 
+mkdir -p ~/.setup
+
 if [ ! -e ~/.setup/circus ]; then
     sudo mv /tmp/taiga-circus.ini /etc/circus/conf.d/taiga.ini
 

--- a/scripts/setup-circus.sh
+++ b/scripts/setup-circus.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-pip3 install circus
+pip3 install circus --no-warn-script-location
 
 cat > /tmp/taiga-circus.ini <<EOF
 [watcher:taiga]
@@ -27,14 +27,36 @@ SHELL=/bin/bash
 USER=taiga
 LANG=en_US.UTF-8
 HOME=/home/$USER
-PYTHONPATH=/home/$USER/.local/lib/python3.4/site-packages
+PYTHONPATH=/home/$USER/.local/lib/python3.8/site-packages
+EOF
+
+cat > /tmp/taiga-circus.service <<EOF
+[Unit]
+Description=Circus process manager
+After=syslog.target network.target nss-lookup.target
+
+[Service]
+User=$USER
+Type=simple
+ExecReload=/home/$USER/.local/bin/circusctl reload
+ExecStart=/home/$USER/.local/bin/circusd /home/$USER/.local/lib/python3.8/site-packages/circus/conf.d/taiga.ini
+Restart=always
+RestartSec=5
+
+[Install]
+WantedBy=default.target
 EOF
 
 mkdir -p ~/.setup
 
 if [ ! -e ~/.setup/circus ]; then
-    sudo mv /tmp/taiga-circus.ini /etc/circus/conf.d/taiga.ini
+    mkdir -p $HOME/.local/lib/python3.8/site-packages/circus/conf.d
+    sudo mv /tmp/taiga-circus.ini $HOME/.local/lib/python3.8/site-packages/circus/conf.d/taiga.ini
+    sudo mv /tmp/taiga-circus.service /etc/systemd/system/circusd.service
 
+    sudo systemctl --system daemon-reload
     sudo service circusd restart
+    sudo systemctl enable circusd
+    
     touch ~/.setup/circus
 fi

--- a/scripts/setup-postgresql.sh
+++ b/scripts/setup-postgresql.sh
@@ -12,6 +12,8 @@ function dropdb-if-needed {
     done
 }
 
+mkdir -p ~/.setup
+
 if [ ! -e ~/.setup/postgresql ]; then
     apt-install-if-needed postgresql postgresql-contrib \
         postgresql-doc postgresql-server-dev-all

--- a/scripts/setup-postgresql.sh
+++ b/scripts/setup-postgresql.sh
@@ -13,8 +13,8 @@ function dropdb-if-needed {
 }
 
 if [ ! -e ~/.setup/postgresql ]; then
-    apt-install-if-needed postgresql-9.5 postgresql-contrib-9.5 \
-        postgresql-doc-9.5 postgresql-server-dev-9.5
+    apt-install-if-needed postgresql postgresql-contrib \
+        postgresql-doc postgresql-server-dev-all
 
     sudo -u postgres createuser --superuser $USER &> /dev/null
     sudo -u postgres createdb $USER &> /dev/null

--- a/scripts/setup-python.sh
+++ b/scripts/setup-python.sh
@@ -1,10 +1,10 @@
 #!/bin/bash
 
-apt-install-if-needed python3 python3-pip python-dev python3-dev python-pip virtualenvwrapper libxml2-dev libxslt1-dev
+apt-install-if-needed python3 python3-pip python-dev python3-dev python3-pip virtualenvwrapper libxml2-dev libxslt1-dev
 source /usr/share/virtualenvwrapper/virtualenvwrapper_lazy.sh
 
 function mkvirtualenv-if-needed {
     for envname in $@; do
-        $(lsvirtualenv | grep -q "$envname") || mkvirtualenv "$envname" -p /usr/bin/python3.5
+        $(lsvirtualenv | grep -q "$envname") || mkvirtualenv "$envname" -p /usr/bin/python3.8
     done
 }

--- a/scripts/setup-rabbitmq.sh
+++ b/scripts/setup-rabbitmq.sh
@@ -30,6 +30,7 @@ function rabbit-activate-plugin {
     fi
 }
 
+mkdir -p ~/.setup
 
 if [ ! -e ~/.setup/rabbitmq ]; then
     touch ~/.setup/rabbitmq

--- a/scripts/setup-redis.sh
+++ b/scripts/setup-redis.sh
@@ -1,5 +1,7 @@
 # redis.sh
 
+mkdir -p ~/.setup
+
 if [ ! -e ~/.setup/redis ]; then
     touch ~/.setup/redis
 

--- a/setup-devel.sh
+++ b/setup-devel.sh
@@ -1,5 +1,11 @@
 #!/bin/bash
 
+if $(locale -a | grep -q 'locale-gen en_US.utf8'); then     
+    echo "Locale en_US.utf8 already enabled."; 
+else
+    echo "Enabling locale en_US.utf8 already enabled."; 
+    sudo locale-gen en_US.utf8
+fi
 
 pushd ~
 mkdir -p logs

--- a/setup-server.sh
+++ b/setup-server.sh
@@ -5,6 +5,7 @@ if [[ $EUID -eq 0 ]]; then
   exit 1
 fi
 
+mkdir -p ~/.setup
 source ./setup-devel.sh
 
 # Post Setup Services

--- a/setup-server.sh
+++ b/setup-server.sh
@@ -5,7 +5,6 @@ if [[ $EUID -eq 0 ]]; then
   exit 1
 fi
 
-mkdir -p ~/.setup
 source ./setup-devel.sh
 
 # Post Setup Services


### PR DESCRIPTION
I made some changes into taiga-scripts files, so now it can be installed over an Ubuntu Server 20.04 LTS by running the setup-server-sh script.

Please, note that the following files has not been tested:
- ./scripts/setup-vars.sh
- ./scripts/setup-redis.sh
- ./scripts/setup-rabbitmq.sh